### PR TITLE
Rdma build yes

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,13 @@ To build TLS as Valkey module:
 Note that sentinel mode does not support TLS module.
 
 To build with experimental RDMA support you'll need RDMA development libraries
-(e.g. librdmacm-dev and libibverbs-dev on Debian/Ubuntu). For now, Valkey only
-supports RDMA as connection module mode. Run:
+(e.g. librdmacm-dev and libibverbs-dev on Debian/Ubuntu).
+
+To build RDMA support as Valkey built-in:
+
+    % make BUILD_RDMA=yes
+
+To build RDMA as Valkey module:
 
     % make BUILD_RDMA=module
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -337,26 +337,27 @@ ifeq ($(BUILD_TLS),module)
 	TLS_MODULE_CFLAGS+=-DUSE_OPENSSL=$(BUILD_MODULE) $(OPENSSL_CFLAGS) -DBUILD_TLS_MODULE=$(BUILD_MODULE)
 endif
 
-BUILD_RDMA:=no
-RDMA_MODULE=
-RDMA_MODULE_NAME:=valkey-rdma$(PROG_SUFFIX).so
-RDMA_MODULE_CFLAGS:=$(FINAL_CFLAGS)
-ifeq ($(BUILD_RDMA),module)
-	FINAL_CFLAGS+=-DUSE_RDMA=$(BUILD_MODULE)
-	RDMA_PKGCONFIG := $(shell $(PKG_CONFIG) --exists librdmacm libibverbs && echo $$?)
+RDMA_LIBS=
+RDMA_PKGCONFIG := $(shell $(PKG_CONFIG) --exists librdmacm libibverbs && echo $$?)
 ifeq ($(RDMA_PKGCONFIG),0)
 	RDMA_LIBS=$(shell $(PKG_CONFIG) --libs librdmacm libibverbs)
 else
 	RDMA_LIBS=-lrdmacm -libverbs
 endif
-	RDMA_MODULE=$(RDMA_MODULE_NAME)
-	RDMA_MODULE_CFLAGS+=-DUSE_RDMA=$(BUILD_YES) -DBUILD_RDMA_MODULE $(RDMA_LIBS)
-else
-ifeq ($(BUILD_RDMA),no)
-    # disable RDMA, do nothing
-else
-    $(error "RDMA is only supported as module (BUILD_RDMA=module), or disabled (BUILD_RDMA=no)")
+
+BUILD_RDMA:=no
+ifeq ($(BUILD_RDMA),yes)
+	FINAL_CFLAGS+=-DUSE_RDMA=$(BUILD_YES) -DBUILD_RDMA_MODULE=$(BUILD_NO)
+	FINAL_LIBS += $(RDMA_LIBS)
 endif
+
+RDMA_MODULE=
+RDMA_MODULE_NAME:=valkey-rdma$(PROG_SUFFIX).so
+RDMA_MODULE_CFLAGS:=$(FINAL_CFLAGS)
+ifeq ($(BUILD_RDMA),module)
+	FINAL_CFLAGS+=-DUSE_RDMA=$(BUILD_MODULE)
+	RDMA_MODULE=$(RDMA_MODULE_NAME)
+	RDMA_MODULE_CFLAGS+=-DUSE_RDMA=$(BUILD_MODULE) -DBUILD_RDMA_MODULE=$(BUILD_MODULE) $(RDMA_LIBS)
 endif
 
 ifndef V
@@ -423,7 +424,7 @@ endif
 ENGINE_NAME=valkey
 SERVER_NAME=$(ENGINE_NAME)-server$(PROG_SUFFIX)
 ENGINE_SENTINEL_NAME=$(ENGINE_NAME)-sentinel$(PROG_SUFFIX)
-ENGINE_SERVER_OBJ=threads_mngr.o adlist.o quicklist.o ae.o anet.o dict.o kvstore.o server.o sds.o zmalloc.o lzf_c.o lzf_d.o pqsort.o zipmap.o sha1.o ziplist.o release.o memory_prefetch.o io_threads.o networking.o util.o object.o db.o replication.o rdb.o t_string.o t_list.o t_set.o t_zset.o t_hash.o config.o aof.o pubsub.o multi.o debug.o sort.o intset.o syncio.o cluster.o cluster_legacy.o cluster_slot_stats.o crc16.o endianconv.o slowlog.o eval.o bio.o rio.o rand.o memtest.o syscheck.o crcspeed.o crccombine.o crc64.o bitops.o sentinel.o notify.o setproctitle.o blocked.o hyperloglog.o latency.o sparkline.o valkey-check-rdb.o valkey-check-aof.o geo.o lazyfree.o module.o evict.o expire.o geohash.o geohash_helper.o childinfo.o defrag.o siphash.o rax.o t_stream.o listpack.o localtime.o lolwut.o lolwut5.o lolwut6.o acl.o tracking.o socket.o tls.o sha256.o timeout.o setcpuaffinity.o monotonic.o mt19937-64.o resp_parser.o call_reply.o script_lua.o script.o functions.o function_lua.o commands.o strl.o connection.o unix.o logreqres.o
+ENGINE_SERVER_OBJ=threads_mngr.o adlist.o quicklist.o ae.o anet.o dict.o kvstore.o server.o sds.o zmalloc.o lzf_c.o lzf_d.o pqsort.o zipmap.o sha1.o ziplist.o release.o memory_prefetch.o io_threads.o networking.o util.o object.o db.o replication.o rdb.o t_string.o t_list.o t_set.o t_zset.o t_hash.o config.o aof.o pubsub.o multi.o debug.o sort.o intset.o syncio.o cluster.o cluster_legacy.o cluster_slot_stats.o crc16.o endianconv.o slowlog.o eval.o bio.o rio.o rand.o memtest.o syscheck.o crcspeed.o crccombine.o crc64.o bitops.o sentinel.o notify.o setproctitle.o blocked.o hyperloglog.o latency.o sparkline.o valkey-check-rdb.o valkey-check-aof.o geo.o lazyfree.o module.o evict.o expire.o geohash.o geohash_helper.o childinfo.o defrag.o siphash.o rax.o t_stream.o listpack.o localtime.o lolwut.o lolwut5.o lolwut6.o acl.o tracking.o socket.o tls.o sha256.o timeout.o setcpuaffinity.o monotonic.o mt19937-64.o resp_parser.o call_reply.o script_lua.o script.o functions.o function_lua.o commands.o strl.o connection.o unix.o logreqres.o rdma.o
 ENGINE_CLI_NAME=$(ENGINE_NAME)-cli$(PROG_SUFFIX)
 ENGINE_CLI_OBJ=anet.o adlist.o dict.o valkey-cli.o zmalloc.o release.o ae.o serverassert.o crcspeed.o crccombine.o crc64.o siphash.o crc16.o monotonic.o cli_common.o mt19937-64.o strl.o cli_commands.o
 ENGINE_BENCHMARK_NAME=$(ENGINE_NAME)-benchmark$(PROG_SUFFIX)

--- a/src/config.c
+++ b/src/config.c
@@ -2641,7 +2641,7 @@ static int applyBind(const char **err) {
     tcp_listener->ct = connectionByType(CONN_TYPE_SOCKET);
     if (changeListener(tcp_listener) == C_ERR) {
         *err = "Failed to bind to specified addresses.";
-        if (tls_listener) closeListener(tls_listener); /* failed with TLS together */
+        if (tls_listener) connCloseListener(tls_listener); /* failed with TLS together */
         return 0;
     }
 
@@ -2653,7 +2653,7 @@ static int applyBind(const char **err) {
         tls_listener->ct = connectionByType(CONN_TYPE_TLS);
         if (changeListener(tls_listener) == C_ERR) {
             *err = "Failed to bind to specified addresses.";
-            closeListener(tcp_listener); /* failed with TCP together */
+            connCloseListener(tcp_listener); /* failed with TCP together */
             return 0;
         }
     }

--- a/src/config.c
+++ b/src/config.c
@@ -1533,10 +1533,27 @@ void rewriteConfigOOMScoreAdjValuesOption(standardConfig *config, const char *na
 }
 
 /* Rewrite the bind option. */
-void rewriteConfigBindOption(standardConfig *config, const char *name, struct rewriteConfigState *state) {
+static void rewriteConfigBindOption(standardConfig *config, const char *name, struct rewriteConfigState *state, char **bindaddr, int bindaddr_count) {
     UNUSED(config);
     int force = 1;
     sds line, addresses;
+
+    /* Rewrite as bind <addr1> <addr2> ... <addrN> */
+    if (bindaddr_count > 0)
+        addresses = sdsjoin(bindaddr, bindaddr_count, " ");
+    else
+        addresses = sdsnew("\"\"");
+    line = sdsnew(name);
+    line = sdscatlen(line, " ", 1);
+    line = sdscatsds(line, addresses);
+    sdsfree(addresses);
+
+    rewriteConfigRewriteLine(state, name, line, force);
+}
+
+/* Rewrite the bind option. */
+static void rewriteConfigSocketBindOption(standardConfig *config, const char *name, struct rewriteConfigState *state) {
+    UNUSED(config);
     int is_default = 0;
 
     /* Compare server.bindaddr with CONFIG_DEFAULT_BINDADDR */
@@ -1556,17 +1573,7 @@ void rewriteConfigBindOption(standardConfig *config, const char *name, struct re
         return;
     }
 
-    /* Rewrite as bind <addr1> <addr2> ... <addrN> */
-    if (server.bindaddr_count > 0)
-        addresses = sdsjoin(server.bindaddr, server.bindaddr_count, " ");
-    else
-        addresses = sdsnew("\"\"");
-    line = sdsnew(name);
-    line = sdscatlen(line, " ", 1);
-    line = sdscatsds(line, addresses);
-    sdsfree(addresses);
-
-    rewriteConfigRewriteLine(state, name, line, force);
+    rewriteConfigBindOption(config, name, state, server.bindaddr, server.bindaddr_count);
 }
 
 /* Rewrite the loadmodule option. */
@@ -2919,8 +2926,9 @@ static sds getConfigNotifyKeyspaceEventsOption(standardConfig *config) {
     return keyspaceEventsFlagsToString(server.notify_keyspace_events);
 }
 
-static int setConfigBindOption(standardConfig *config, sds *argv, int argc, const char **err) {
+static int setConfigBindOption(standardConfig *config, sds *argv, int argc, const char **err, char **bindaddr, int *bindaddr_count) {
     UNUSED(config);
+    int orig_bindaddr_count = *bindaddr_count;
     int j;
 
     if (argc > CONFIG_BINDADDR_MAX) {
@@ -2932,13 +2940,19 @@ static int setConfigBindOption(standardConfig *config, sds *argv, int argc, cons
     if (argc == 1 && sdslen(argv[0]) == 0) argc = 0;
 
     /* Free old bind addresses */
-    for (j = 0; j < server.bindaddr_count; j++) {
-        zfree(server.bindaddr[j]);
+    for (j = 0; j < orig_bindaddr_count; j++) {
+        zfree(bindaddr[j]);
     }
-    for (j = 0; j < argc; j++) server.bindaddr[j] = zstrdup(argv[j]);
-    server.bindaddr_count = argc;
+    for (j = 0; j < argc; j++) bindaddr[j] = zstrdup(argv[j]);
+    *bindaddr_count = argc;
 
     return 1;
+}
+
+static int setConfigSocketBindOption(standardConfig *config, sds *argv, int argc, const char **err) {
+    UNUSED(config);
+
+    return setConfigBindOption(config, argv, argc, err, server.bindaddr, &server.bindaddr_count);
 }
 
 static int setConfigReplicaOfOption(standardConfig *config, sds *argv, int argc, const char **err) {
@@ -3310,7 +3324,7 @@ standardConfig static_configs[] = {
     createSpecialConfig("client-output-buffer-limit", NULL, MODIFIABLE_CONFIG | MULTI_ARG_CONFIG, setConfigClientOutputBufferLimitOption, getConfigClientOutputBufferLimitOption, rewriteConfigClientOutputBufferLimitOption, NULL),
     createSpecialConfig("oom-score-adj-values", NULL, MODIFIABLE_CONFIG | MULTI_ARG_CONFIG, setConfigOOMScoreAdjValuesOption, getConfigOOMScoreAdjValuesOption, rewriteConfigOOMScoreAdjValuesOption, updateOOMScoreAdj),
     createSpecialConfig("notify-keyspace-events", NULL, MODIFIABLE_CONFIG, setConfigNotifyKeyspaceEventsOption, getConfigNotifyKeyspaceEventsOption, rewriteConfigNotifyKeyspaceEventsOption, NULL),
-    createSpecialConfig("bind", NULL, MODIFIABLE_CONFIG | MULTI_ARG_CONFIG, setConfigBindOption, getConfigBindOption, rewriteConfigBindOption, applyBind),
+    createSpecialConfig("bind", NULL, MODIFIABLE_CONFIG | MULTI_ARG_CONFIG, setConfigSocketBindOption, getConfigBindOption, rewriteConfigSocketBindOption, applyBind),
     createSpecialConfig("replicaof", "slaveof", IMMUTABLE_CONFIG | MULTI_ARG_CONFIG, setConfigReplicaOfOption, getConfigReplicaOfOption, rewriteConfigReplicaOfOption, NULL),
     createSpecialConfig("latency-tracking-info-percentiles", NULL, MODIFIABLE_CONFIG | MULTI_ARG_CONFIG, setConfigLatencyTrackingInfoPercentilesOutputOption, getConfigLatencyTrackingInfoPercentilesOutputOption, rewriteConfigLatencyTrackingInfoPercentilesOutputOption, NULL),
 

--- a/src/connection.c
+++ b/src/connection.c
@@ -66,6 +66,9 @@ int connTypeInitialize(void) {
     /* may fail if without BUILD_TLS=yes */
     RedisRegisterConnectionTypeTLS();
 
+    /* may fail if without BUILD_RDMA=yes */
+    RegisterConnectionTypeRdma();
+
     return C_OK;
 }
 

--- a/src/connection.h
+++ b/src/connection.h
@@ -60,6 +60,7 @@ typedef enum {
 #define CONN_TYPE_SOCKET "tcp"
 #define CONN_TYPE_UNIX "unix"
 #define CONN_TYPE_TLS "tls"
+#define CONN_TYPE_RDMA "rdma"
 #define CONN_TYPE_MAX 8 /* 8 is enough to be extendable */
 
 typedef void (*ConnectionCallbackFunc)(struct connection *conn);

--- a/src/connection.h
+++ b/src/connection.h
@@ -463,6 +463,7 @@ sds getListensInfoString(sds info);
 int RedisRegisterConnectionTypeSocket(void);
 int RedisRegisterConnectionTypeUnix(void);
 int RedisRegisterConnectionTypeTLS(void);
+int RegisterConnectionTypeRdma(void);
 
 /* Return 1 if connection is using TLS protocol, 0 if otherwise. */
 static inline int connIsTLS(connection *conn) {

--- a/src/connection.h
+++ b/src/connection.h
@@ -79,6 +79,7 @@ typedef struct ConnectionType {
     int (*addr)(connection *conn, char *ip, size_t ip_len, int *port, int remote);
     int (*is_local)(connection *conn);
     int (*listen)(connListener *listener);
+    void (*closeListener)(connListener *listener);
 
     /* create/shutdown/close connection */
     connection *(*conn_create)(void);
@@ -440,6 +441,13 @@ int connTypeProcessPendingData(void);
 /* Listen on an initialized listener */
 static inline int connListen(connListener *listener) {
     return listener->ct->listen(listener);
+}
+
+/* Close a listened listener */
+static inline void connCloseListener(connListener *listener) {
+    if (listener->count) {
+        listener->ct->closeListener(listener);
+    }
 }
 
 /* Get accept_handler of a connection type */

--- a/src/rdma.c
+++ b/src/rdma.c
@@ -10,9 +10,10 @@
 
 #define VALKEYMODULE_CORE_MODULE
 #include "server.h"
-
-#if defined USE_RDMA && defined __linux__ /* currently RDMA is only supported on Linux */
 #include "connection.h"
+
+#if defined __linux__ /* currently RDMA is only supported on Linux */
+#if (USE_RDMA == 1 /* BUILD_YES */) || ((USE_RDMA == 2 /* BUILD_MODULE */) && (BUILD_RDMA_MODULE == 2))
 #include "connhelpers.h"
 
 #include <assert.h>
@@ -1761,7 +1762,20 @@ ConnectionType *connectionTypeRdma(void) {
     return ct_rdma;
 }
 
-#ifdef BUILD_RDMA_MODULE
+int RegisterConnectionTypeRdma(void) {
+    return connTypeRegister(&CT_RDMA);
+}
+
+#else
+
+int RegisterConnectionTypeRdma(void) {
+    serverLog(LL_VERBOSE, "Connection type %s not builtin", CONN_TYPE_RDMA);
+    return C_ERR;
+}
+
+#endif
+
+#if BUILD_RDMA_MODULE == 2 /* BUILD_MODULE */
 
 #include "release.h"
 
@@ -1799,4 +1813,11 @@ int ValkeyModule_OnUnload(void *arg) {
 
 #endif /* BUILD_RDMA_MODULE */
 
-#endif /* USE_RDMA && __linux__ */
+#else /* __linux__ */
+
+int RegisterConnectionTypeRdma(void) {
+    serverLog(LL_VERBOSE, "Connection type %s is supported on Linux only", CONN_TYPE_RDMA);
+    return C_ERR;
+}
+
+#endif /* __linux__ */

--- a/src/rdma.c
+++ b/src/rdma.c
@@ -128,11 +128,9 @@ typedef struct rdma_listener {
 static list *pending_list;
 
 static rdma_listener *rdma_listeners;
+static serverRdmaContextConfig *rdma_config;
 
 static ConnectionType CT_RDMA;
-
-static int valkey_rdma_rx_size = VALKEY_RDMA_DEFAULT_RX_SIZE;
-static int valkey_rdma_comp_vector = -1; /* -1 means a random one */
 
 static void serverRdmaError(char *err, const char *fmt, ...) {
     va_list ap;
@@ -250,7 +248,7 @@ static int rdmaSetupIoBuf(RdmaContext *ctx, struct rdma_cm_id *cm_id) {
 
     /* setup recv buf & MR */
     access = IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_READ | IBV_ACCESS_REMOTE_WRITE;
-    length = valkey_rdma_rx_size;
+    length = rdma_config->rx_size;
     ctx->rx.addr = page_aligned_zalloc(length);
     ctx->rx.length = length;
     ctx->rx.mr = ibv_reg_mr(ctx->pd, ctx->rx.addr, length, access);
@@ -273,6 +271,7 @@ static int rdmaCreateResource(RdmaContext *ctx, struct rdma_cm_id *cm_id) {
     struct ibv_comp_channel *comp_channel = NULL;
     struct ibv_cq *cq = NULL;
     struct ibv_pd *pd = NULL;
+    int comp_vector = rdma_config->comp_vector;
 
     if (ibv_query_device(cm_id->verbs, &device_attr)) {
         serverLog(LL_WARNING, "RDMA: ibv ibv query device failed");
@@ -295,8 +294,13 @@ static int rdmaCreateResource(RdmaContext *ctx, struct rdma_cm_id *cm_id) {
 
     ctx->comp_channel = comp_channel;
 
+    /* negative number means a random one */
+    if (comp_vector < 0) {
+        comp_vector = abs((int)random());
+    }
+
     cq = ibv_create_cq(cm_id->verbs, VALKEY_RDMA_MAX_WQE * 2, NULL, comp_channel,
-                       valkey_rdma_comp_vector % cm_id->verbs->num_comp_vectors);
+                       comp_vector % cm_id->verbs->num_comp_vectors);
     if (!cq) {
         serverLog(LL_WARNING, "RDMA: ibv create cq failed");
         return C_ERR;
@@ -1566,6 +1570,7 @@ int connRdmaListen(connListener *listener) {
         rdma_listener++;
     }
 
+    rdma_config = listener->priv;
     return C_OK;
 }
 
@@ -1584,6 +1589,7 @@ static void connRdmaCloseListener(connListener *listener) {
     listener->count = 0;
     zfree(rdma_listeners);
     rdma_listeners = NULL;
+    rdma_config = NULL;
 }
 
 static int connRdmaAddr(connection *conn, char *ip, size_t ip_len, int *port, int remote) {
@@ -1744,17 +1750,6 @@ static ConnectionType CT_RDMA = {
     .process_pending_data = rdmaProcessPendingData,
 };
 
-static struct connListener *rdmaListener(void) {
-    static struct connListener *listener = NULL;
-
-    if (listener) return listener;
-
-    listener = listenerByType(CONN_TYPE_RDMA);
-    serverAssert(listener != NULL);
-
-    return listener;
-}
-
 ConnectionType *connectionTypeRdma(void) {
     static ConnectionType *ct_rdma = NULL;
 
@@ -1766,117 +1761,15 @@ ConnectionType *connectionTypeRdma(void) {
     return ct_rdma;
 }
 
-/* rdma listener has different create/close logic from TCP, we can't re-use 'int changeListener(connListener *listener)'
- * directly */
-static int rdmaChangeListener(void) {
-    struct connListener *listener = rdmaListener();
-
-    connRdmaCloseListener(listener);
-    /* Just close the server if port disabled */
-    if (listener->port == 0) {
-        if (server.set_proc_title) serverSetProcTitle(NULL);
-        return VALKEYMODULE_OK;
-    }
-
-    /* Re-create listener */
-    if (connListen(listener) != C_OK) {
-        return VALKEYMODULE_ERR;
-    }
-
-    /* Create event handlers */
-    if (createSocketAcceptHandler(listener, listener->ct->accept_handler) != C_OK) {
-        serverPanic("Unrecoverable error creating %s accept handler.", listener->ct->get_type(NULL));
-    }
-
-    if (server.set_proc_title) serverSetProcTitle(NULL);
-
-    return VALKEYMODULE_OK;
-}
-
 #ifdef BUILD_RDMA_MODULE
 
 #include "release.h"
 
-static long long rdmaGetPort(const char *name, void *privdata) {
-    UNUSED(name);
-    UNUSED(privdata);
-    struct connListener *listener = rdmaListener();
-
-    return listener->port;
-}
-
-static int rdmaSetPort(const char *name, long long val, void *privdata, ValkeyModuleString **err) {
-    UNUSED(name);
-    UNUSED(privdata);
-    UNUSED(err);
-    struct connListener *listener = rdmaListener();
-    listener->port = val;
-
-    return VALKEYMODULE_OK;
-}
-
-static ValkeyModuleString *rdma_bind;
-
-static void rdmaBuildBind(void *ctx) {
-    struct connListener *listener = rdmaListener();
-
-    if (rdma_bind) ValkeyModule_FreeString(NULL, rdma_bind);
-
-    sds rdma_bind_str = sdsjoin(listener->bindaddr, listener->bindaddr_count, " ");
-    rdma_bind = ValkeyModule_CreateString(ctx, rdma_bind_str, sdslen(rdma_bind_str));
-}
-
-static ValkeyModuleString *rdmaGetBind(const char *name, void *privdata) {
-    UNUSED(name);
-    UNUSED(privdata);
-
-    return rdma_bind;
-}
-
-static int rdmaSetBind(const char *name, ValkeyModuleString *val, void *privdata, ValkeyModuleString **err) {
-    UNUSED(name);
-    UNUSED(err);
-    struct connListener *listener = rdmaListener();
-    const char *bind = ValkeyModule_StringPtrLen(val, NULL);
-    int nexts;
-    sds *exts = sdssplitlen(bind, strlen(bind), " ", 1, &nexts);
-
-    if (nexts > CONFIG_BINDADDR_MAX) {
-        serverLog(LL_WARNING, "RDMA: Unsupported bind ( > %d)", CONFIG_BINDADDR_MAX);
-        return VALKEYMODULE_ERR;
-    }
-
-    /* Free old bind addresses */
-    for (int j = 0; j < listener->bindaddr_count; j++) {
-        zfree(listener->bindaddr[j]);
-    }
-
-    for (int j = 0; j < nexts; j++) listener->bindaddr[j] = zstrdup(exts[j]);
-    listener->bindaddr_count = nexts;
-
-    sdsfreesplitres(exts, nexts);
-    rdmaBuildBind(privdata);
-
-    return VALKEYMODULE_OK;
-}
-
-static int rdmaApplyListener(ValkeyModuleCtx *ctx, void *privdata, ValkeyModuleString **err) {
-    UNUSED(ctx);
-    UNUSED(privdata);
-    UNUSED(err);
-
-    return rdmaChangeListener();
-}
-
-static void rdmaListenerAddConfig(void *ctx) {
-    serverAssert(ValkeyModule_RegisterNumericConfig(ctx, "port", 0, VALKEYMODULE_CONFIG_DEFAULT, 0, 65535, rdmaGetPort,
-                                                    rdmaSetPort, rdmaApplyListener, NULL) == VALKEYMODULE_OK);
-    serverAssert(ValkeyModule_RegisterStringConfig(ctx, "bind", "", VALKEYMODULE_CONFIG_DEFAULT, rdmaGetBind,
-                                                   rdmaSetBind, rdmaApplyListener, ctx) == VALKEYMODULE_OK);
-    serverAssert(ValkeyModule_LoadConfigs(ctx) == VALKEYMODULE_OK);
-}
 
 int ValkeyModule_OnLoad(void *ctx, ValkeyModuleString **argv, int argc) {
+    UNUSED(argv);
+    UNUSED(argc);
+
     /* Connection modules MUST be part of the same build as valkey. */
     if (strcmp(REDIS_BUILD_ID_RAW, serverBuildIdRaw())) {
         serverLog(LL_NOTICE, "Connection type %s was not built together with the valkey-server used.", CONN_TYPE_RDMA);
@@ -1894,40 +1787,6 @@ int ValkeyModule_OnLoad(void *ctx, ValkeyModuleString **argv, int argc) {
     ValkeyModule_SetModuleOptions(ctx, VALKEYMODULE_OPTIONS_HANDLE_REPL_ASYNC_LOAD);
 
     if (connTypeRegister(&CT_RDMA) != C_OK) return VALKEYMODULE_ERR;
-
-    rdmaListenerAddConfig(ctx);
-
-    struct connListener *listener = rdmaListener();
-    listener->ct = connectionTypeRdma();
-    listener->bindaddr = zcalloc_num(CONFIG_BINDADDR_MAX, sizeof(listener->bindaddr[0]));
-
-    for (int i = 0; i < argc; i++) {
-        robj *str = (robj *)argv[i];
-        int nexts;
-        sds *exts = sdssplitlen(str->ptr, strlen(str->ptr), "=", 1, &nexts);
-        if (nexts != 2) {
-            serverLog(LL_WARNING, "RDMA: Unsupported argument \"%s\"", (char *)str->ptr);
-            return VALKEYMODULE_ERR;
-        }
-
-        if (!strcasecmp(exts[0], "bind")) {
-            listener->bindaddr[listener->bindaddr_count++] = zstrdup(exts[1]);
-        } else if (!strcasecmp(exts[0], "port")) {
-            listener->port = atoi(exts[1]);
-        } else if (!strcasecmp(exts[0], "rx-size")) {
-            valkey_rdma_rx_size = atoi(exts[1]);
-        } else if (!strcasecmp(exts[0], "comp-vector")) {
-            valkey_rdma_comp_vector = atoi(exts[1]);
-        } else {
-            serverLog(LL_WARNING, "RDMA: Unsupported argument \"%s\"", (char *)str->ptr);
-            return VALKEYMODULE_ERR;
-        }
-
-        sdsfreesplitres(exts, nexts);
-    }
-
-    rdmaBuildBind(ctx);
-    if (valkey_rdma_comp_vector == -1) valkey_rdma_comp_vector = abs((int)random());
 
     return VALKEYMODULE_OK;
 }

--- a/src/server.c
+++ b/src/server.c
@@ -2808,6 +2808,17 @@ void initListeners(void) {
         listener->priv = &server.unix_ctx_config; /* Unix socket specified */
     }
 
+    if (server.rdma_ctx_config.port != 0) {
+        conn_index = connectionIndexByType(CONN_TYPE_RDMA);
+        if (conn_index < 0) serverPanic("Failed finding connection listener of %s", CONN_TYPE_RDMA);
+        listener = &server.listeners[conn_index];
+        listener->bindaddr = server.rdma_ctx_config.bindaddr;
+        listener->bindaddr_count = server.rdma_ctx_config.bindaddr_count;
+        listener->port = server.rdma_ctx_config.port;
+        listener->ct = connectionByType(CONN_TYPE_RDMA);
+        listener->priv = &server.rdma_ctx_config;
+    }
+
     /* create all the configured listener, and add handler to start to accept */
     int listen_fds = 0;
     for (int j = 0; j < CONN_TYPE_MAX; j++) {

--- a/src/server.h
+++ b/src/server.h
@@ -1603,6 +1603,17 @@ typedef struct serverUnixContextConfig {
 } serverUnixContextConfig;
 
 /*-----------------------------------------------------------------------------
+ * RDMA Context Configuration
+ *----------------------------------------------------------------------------*/
+typedef struct serverRdmaContextConfig {
+    char *bindaddr[CONFIG_BINDADDR_MAX];
+    int bindaddr_count;
+    int port;
+    int rx_size;
+    int comp_vector;
+} serverRdmaContextConfig;
+
+/*-----------------------------------------------------------------------------
  * AOF manifest definition
  *----------------------------------------------------------------------------*/
 typedef enum {
@@ -2210,6 +2221,7 @@ struct valkeyServer {
     int tls_auth_clients;
     serverTLSContextConfig tls_ctx_config;
     serverUnixContextConfig unix_ctx_config;
+    serverRdmaContextConfig rdma_ctx_config;
     /* cpu affinity */
     char *server_cpulist;      /* cpu affinity list of server main/io thread. */
     char *bio_cpulist;         /* cpu affinity list of bio thread. */

--- a/src/server.h
+++ b/src/server.h
@@ -3273,7 +3273,6 @@ void setupSignalHandlers(void);
 int createSocketAcceptHandler(connListener *sfd, aeFileProc *accept_handler);
 connListener *listenerByType(const char *typename);
 int changeListener(connListener *listener);
-void closeListener(connListener *listener);
 struct serverCommand *lookupSubcommand(struct serverCommand *container, sds sub_name);
 struct serverCommand *lookupCommand(robj **argv, int argc);
 struct serverCommand *lookupCommandBySdsLogic(dict *commands, sds s);

--- a/src/socket.c
+++ b/src/socket.c
@@ -339,6 +339,19 @@ static int connSocketListen(connListener *listener) {
     return listenToPort(listener);
 }
 
+static void connSocketCloseListener(connListener *listener) {
+    int j;
+
+    for (j = 0; j < listener->count; j++) {
+        if (listener->fd[j] == -1) continue;
+
+        aeDeleteFileEvent(server.el, listener->fd[j], AE_READABLE);
+        close(listener->fd[j]);
+    }
+
+    listener->count = 0;
+}
+
 static int connSocketBlockingConnect(connection *conn, const char *addr, int port, long long timeout) {
     int fd = anetTcpNonBlockConnect(NULL, addr, port);
     if (fd == -1) {
@@ -395,6 +408,7 @@ static ConnectionType CT_Socket = {
     .addr = connSocketAddr,
     .is_local = connSocketIsLocal,
     .listen = connSocketListen,
+    .closeListener = connSocketCloseListener,
 
     /* create/shutdown/close connection */
     .conn_create = connCreateSocket,

--- a/src/tls.c
+++ b/src/tls.c
@@ -799,6 +799,10 @@ static int connTLSListen(connListener *listener) {
     return listenToPort(listener);
 }
 
+static void connTLSCloseListener(connListener *listener) {
+    connectionTypeTcp()->closeListener(listener);
+}
+
 static void connTLSShutdown(connection *conn_) {
     tls_connection *conn = (tls_connection *)conn_;
 
@@ -1127,6 +1131,7 @@ static ConnectionType CT_TLS = {
     .addr = connTLSAddr,
     .is_local = connTLSIsLocal,
     .listen = connTLSListen,
+    .closeListener = connTLSCloseListener,
 
     /* create/shutdown/close connection */
     .conn_create = connCreateTLS,

--- a/src/unix.c
+++ b/src/unix.c
@@ -74,6 +74,10 @@ static int connUnixListen(connListener *listener) {
     return C_OK;
 }
 
+static void connUnixCloseListener(connListener *listener) {
+    connectionTypeTcp()->closeListener(listener);
+}
+
 static connection *connCreateUnix(void) {
     connection *conn = zcalloc(sizeof(connection));
     conn->type = &CT_Unix;
@@ -174,6 +178,7 @@ static ConnectionType CT_Unix = {
     .addr = connUnixAddr,
     .is_local = connUnixIsLocal,
     .listen = connUnixListen,
+    .closeListener = connUnixCloseListener,
 
     /* create/shutdown/close connection */
     .conn_create = connCreateUnix,

--- a/tests/rdma/run.py
+++ b/tests/rdma/run.py
@@ -63,7 +63,7 @@ def test_rdma(ipaddr):
     rdmapath = valkeydir + "/src/valkey-rdma.so"
     svrcmd = [svrpath, "--port", "0", "--loglevel", "verbose", "--protected-mode", "yes",
              "--appendonly", "no", "--daemonize", "no", "--dir", valkeydir + "/tests/rdma/tmp",
-             "--loadmodule", rdmapath, "port=6379", "bind=" + ipaddr]
+             "--loadmodule", rdmapath, "--rdma-port", "6379", "--rdma-bind", ipaddr]
 
     svr = subprocess.Popen(svrcmd, shell=False, stdout=subprocess.PIPE)
     try:

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -558,6 +558,10 @@ start_server {tags {"introspection"}} {
             req-res-logfile
             client-default-resp
             dual-channel-replication-enabled
+            rdma-comp-vector
+            rdma-rx-size
+            rdma-bind
+            rdma-port
         }
 
         if {!$::tls} {

--- a/valkey.conf
+++ b/valkey.conf
@@ -300,6 +300,26 @@ tcp-keepalive 300
 #
 # tls-session-cache-timeout 60
 
+################################### RDMA ######################################
+
+# By default, RDMA is disabled. To enable it, the "rdma-port" configuration
+# directive can be used to define RDMA-listening ports. Note that RDMA is able
+# to build as builtin or module. To enable RDMA on the port, use:
+#
+# rdma-port 6379
+# rdma-bind 192.168.1.100
+
+# The RDMA receive transfer buffer is 1M, it can be set between 64K and 16M.
+#
+# rdma-rx-size 262144
+
+# The RDMA completion queue will use the completion vector for signaling completion
+# events. Note that it must be at least zero and less than the maximum number of
+# completion vectors from the RDMA device. Once a negative number (-1) is specified,
+# the server will use a random vector for a new connection. The default vector is -1.
+#
+# rdma-comp-vector 0
+
 ################################# GENERAL #####################################
 
 # By default the server does not run as a daemon. Use 'yes' if you need it.


### PR DESCRIPTION
There are several patches in this PR:
* Abstract set/rewrite config bind option: `bind` option is a special config, `socket` and `tls` are using the same one. However RDMA uses the similar style but different one. Use a bit abstract work to make it flexible for both `socket` and `RDMA`. Even for QUIC in the future.
* Introduce closeListener for connection type: closing socket by a simple syscall would be fine, RDMA has complex logic. Introduce connection type specific close listener method.
* RDMA: Use valkey.conf style instead of module parameters: use `--rdma-bind` and `--rdma-port` style instead of module parameters.
* RDMA: Support builtin: support `make BUILD_RDMA=yes`. module style is still kept for now. Once module style is decided to drop, I volunteer to do it for TLS and RDMA together.

Each patch has independent functionality, also been tested by CI and local commands, so request no-squash merge for this PR.